### PR TITLE
feat: add logic to handle mongoose mixed type

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ exports.addSchema = function (base, schemaName, schema) {
     if (field.options.required) definition.required.push(fieldName);
     var type = field.instance.toLowerCase();
     if (['date', 'objectid'].indexOf(type) !== -1) type = 'string';
+    if (['mixed'].indexOf(type) !== -1) type = 'object';
     definition.properties[fieldName] = {type: type};
     if (type === 'array') definition.properties[fieldName].items = {type: 'string'};
   }

--- a/test.js
+++ b/test.js
@@ -20,7 +20,8 @@ const mySchema = new mongoose.Schema({
   isAdmin: Boolean,
   activities: [{type: ObjectId, ref: 'activity'}], // proxy value from activity collection (members.user): it shouldn't be edited directly
   lastLogin: Date,
-  bounces: {type: Number, required: true, default: 0}
+  bounces: {type: Number, required: true, default: 0},
+  thumbnails: { type: 'Mixed' }
 }, {
   timestamps: true,
   id: false,


### PR DESCRIPTION
Add logic to handle Mongoose type `Schema.Types.Mixed` as type 'mixed' is not a valid swagger type.